### PR TITLE
manually move SALayer into the correct new position + supporting rework

### DIFF
--- a/appkit/SAAppDelegate.h
+++ b/appkit/SAAppDelegate.h
@@ -14,6 +14,8 @@
 #import "SAVideoExportSettings.h"
 #import "SAVideoExportSettingsController.h"
 
+extern const int SLIDER_HEIGHT_IN_PIXELS;
+
 @interface SAAppDelegate : NSObject <NSApplicationDelegate>
 {
     BOOL inaugural;

--- a/appkit/SAAppDelegate.m
+++ b/appkit/SAAppDelegate.m
@@ -66,7 +66,7 @@
                     layer.timeValue = 0;
 					if (@available(macOS 11, *))
 					{
-						layer.position = NSMakePoint(0, 0);
+						layer.position = NSMakePoint(0, 29);
 					}
 					else
 					{

--- a/appkit/SAAppDelegate.m
+++ b/appkit/SAAppDelegate.m
@@ -19,6 +19,8 @@
 #import "SAMacroblockedBounded.h"
 @implementation SAAppDelegate
 
+const int SLIDER_HEIGHT_IN_PIXELS = 29;
+
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
     inaugural = YES;
@@ -66,7 +68,7 @@
                     layer.timeValue = 0;
 					if (@available(macOS 11, *))
 					{
-						layer.position = NSMakePoint(0, 29);
+						layer.position = NSMakePoint(0, SLIDER_HEIGHT_IN_PIXELS);
 					}
 					else
 					{

--- a/appkit/SAMacView.m
+++ b/appkit/SAMacView.m
@@ -8,6 +8,7 @@
 
 #import "SAMacView.h"
 #import "SALayer.h"
+#import "SAAppDelegate.h"
 
 @implementation SAMacView
 
@@ -29,7 +30,7 @@
     self.layer.bounds = [self bounds];
     if (@available(macOS 11, *))
     {
-        self.layer.position = NSMakePoint(0, 29);
+        self.layer.position = NSMakePoint(0, SLIDER_HEIGHT_IN_PIXELS);
     }
     else
     {

--- a/appkit/SAMacView.m
+++ b/appkit/SAMacView.m
@@ -29,7 +29,7 @@
     self.layer.bounds = [self bounds];
     if (@available(macOS 11, *))
     {
-        self.layer.position = NSMakePoint(0, 0);
+        self.layer.position = NSMakePoint(0, 29);
     }
     else
     {

--- a/appkit/SAMacView.m
+++ b/appkit/SAMacView.m
@@ -12,17 +12,6 @@
 
 @implementation SAMacView
 
-/* -(void)drawRect:(NSRect)dirtyRect
-{
-    CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
-    [viewHelper drawRect: dirtyRect Context: context Frame: frame];
-    
-    frame++;
-    
-    if (frame>=[viewHelper frames])
-        frame = 0;
-} */
-
 -(void) setFrameSize: (NSSize)newSize
 {
     [super setFrameSize:newSize];

--- a/coregraphics/SALayer.m
+++ b/coregraphics/SALayer.m
@@ -89,7 +89,9 @@
 
 -(void)drawInContext:(CGContextRef)context
 {
-    [viewHelper drawRect:[self bounds] Context:context Frame:self.timeValue];
+	CGContextTranslateCTM(context, 0, -29);
+	[viewHelper drawRect:[self bounds] Context:context Frame:self.timeValue];
+	CGContextTranslateCTM(context, 0, +29);
 }
 
 -(SAViewHelper*) viewHelper

--- a/coregraphics/SALayer.m
+++ b/coregraphics/SALayer.m
@@ -7,6 +7,7 @@
 //
 
 #import "SALayer.h"
+#import "SAAppDelegate.h"
 
 @implementation SALayer
 
@@ -89,9 +90,9 @@
 
 -(void)drawInContext:(CGContextRef)context
 {
-	CGContextTranslateCTM(context, 0, -29);
+	CGContextTranslateCTM(context, 0, -SLIDER_HEIGHT_IN_PIXELS);
 	[viewHelper drawRect:[self bounds] Context:context Frame:self.timeValue];
-	CGContextTranslateCTM(context, 0, +29);
+	CGContextTranslateCTM(context, 0, +SLIDER_HEIGHT_IN_PIXELS);
 }
 
 -(SAViewHelper*) viewHelper

--- a/coregraphics/SAMacroblockedBounded.h
+++ b/coregraphics/SAMacroblockedBounded.h
@@ -18,6 +18,7 @@
 
 -(id)initWithBounded:(NSObject*) designatedBounded AndMacroblockOfWidth:(uint)designatedMacroblockWidth AndHeight:(uint)designatedMacroblockHeight;
 -(NSRect)bounds;
+-(NSRect)frame;
 +(NSRect)makeRectWithWidth:(int) width Height:(int) height;
 
 @end

--- a/coregraphics/SAMacroblockedBounded.m
+++ b/coregraphics/SAMacroblockedBounded.m
@@ -45,6 +45,13 @@
                                              Height:macroblockHeight * (int)ceil((double)bounds.size.height / (double)macroblockHeight)];
 }
 
+-(NSRect)frame
+{
+	NSRect frame = (NSRect)[_bounded frame];
+	return [SAMacroblockedBounded makeRectWithWidth:macroblockWidth * (int)ceil((double)frame.size.width / (double)macroblockWidth)
+											 Height:macroblockHeight * (int)ceil((double)frame.size.height / (double)macroblockHeight)];
+}
+
 +(NSRect)makeRectWithWidth:(int) width Height:(int) height
 {
     NSRect myRect;

--- a/coregraphics/SAMacroblockedBounded.m
+++ b/coregraphics/SAMacroblockedBounded.m
@@ -48,8 +48,7 @@
 -(NSRect)frame
 {
 	NSRect frame = (NSRect)[_bounded frame];
-	return [SAMacroblockedBounded makeRectWithWidth:macroblockWidth * (int)ceil((double)frame.size.width / (double)macroblockWidth)
-											 Height:macroblockHeight * (int)ceil((double)frame.size.height / (double)macroblockHeight)];
+	return frame;
 }
 
 +(NSRect)makeRectWithWidth:(int) width Height:(int) height

--- a/coregraphics/SAViewHelper.h
+++ b/coregraphics/SAViewHelper.h
@@ -16,7 +16,7 @@
 
 @interface SAViewHelper : NSObject<CALayerDelegate, NSAnimationDelegate>
 {
-    NSString* spiritedArraySourceFilePath; // TODO change this to an NSArray* of string?
+    NSString* spiritedArraySourceFilePath;
     SpiritedArray* content;
     SpiritedArray* tileContent;
     SAMetapixelPalette* scaledMetapixelPalette;

--- a/coregraphics/SAViewHelper.m
+++ b/coregraphics/SAViewHelper.m
@@ -60,7 +60,7 @@
     
     if (spiritedArray == nil || [spiritedArray frames]==0)
     {
-        NSLog(@"NOT drawing GIF");
+        // NSLog(@"NOT drawing GIF");
     }
     else
     {
@@ -74,7 +74,7 @@
                                      backgroundColor.Green/255.0f,
                                      backgroundColor.Blue/255.0f,
                                      1.0f);
-            CGContextFillRect(context, [self bounds]);
+            CGContextFillRect(context, [self frame]);
         }
         else
         {
@@ -232,6 +232,17 @@
     {
         content = nil;
     }
+}
+
+-(NSRect) frame
+{
+	if (_bounded==nil)
+	{
+		[NSException raise:@"SAViewHelper Unitialized"
+					format:@"_bounded property has not been configured at %d", (int)__LINE__];
+	}
+	
+	return [_bounded frame];
 }
 
 -(NSRect) bounds

--- a/foundationkit/SAConcreteBounded.m
+++ b/foundationkit/SAConcreteBounded.m
@@ -25,6 +25,11 @@
     return bounds;
 }
 
+-(NSRect) frame
+{
+	return bounds;
+}
+
 -(NSString *)description
 {
     return [NSString stringWithFormat:@"<SAConcreteBounded: x=%f, y=%f, widht=%f, height=%f>", bounds.origin.x, bounds.origin.y, bounds.size.width, bounds.size.height];


### PR DESCRIPTION
~~Addresses https://github.com/dhorlick/spirited_array/issues/8~~

In recent macOS versions, Apple has changed things so that every Window content view has an associated layer. This layer gets assigned as a parent layer for all subview layers.

~~Consequentially, layers are no longer positioned relative to their host view (in this case, `SAMacView`), but rather to the Window content view.~~

~~Furthermore, their `drawInContext(CGContextRef)` coordinate system is no longer relative to their host view, either. (Which, as an aside, makes no sense to me and seems to violate separation of concerns, since a child layer now has to "know" where it is to draw itself correctly…)~~

This PR ~~fixes the recently-introduced misalignment so that animation once again appears where it used to by~~
   1. manually positioning (and maintaining) the layer back to above (not overlapping) the bottom width slider
   1. translating the CGContextRef before and after drawing

This also necessitated a slight change to how backgrounds are rendered, so that they target their host's _frame_, not their hosts bounds.