### PR TITLE
require macOS 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@ _Spirited Array_ is a Mac application for de-pixelating and then whimsically re-
 
 # Requirements
 
-As of v1.0.3, Spirited Array is now a universal binary for both Intel and Apple Silicon macs. Additionally, it also now requires macOS 11 or later.
+Spirited Array is a universal binary for both Intel and Apple Silicon macs. It requires macOS 12 or later.
 
-v1.0.2 will run on macOS versions as old as 10.7 and at least as new as 15.1.
+v1.0.3 will also run on macOS 11.
+
+v1.0.2 will run on macOS versions as old as 10.7 and at least as new as 15.1. But it's also Intel-only and requires Rosetta 2 to run on Apple Silicon.
 
 # Operation
 
@@ -17,6 +19,8 @@ An attempt will be made to recognize any pixelation your file exhibits, and remo
 | _screenshot of animation processed from prguitarman's "Pop Tart Cat" GIF (popularized as "Nyan Cat" in a video by saraj00n.)_ |
 
 You may choose different tiling strategies with the _Tiling_ pull-down menu.
+
+The _Blur_ menu can be used to apply a Gaussian Blur filter to the animation.
 
 To change the dimensions of the virtual array, simply resize the animation window.
 

--- a/appkit/SAAppDelegate.m
+++ b/appkit/SAAppDelegate.m
@@ -66,14 +66,7 @@ const int SLIDER_HEIGHT_IN_PIXELS = 29;
                     
 					layer.bounds = [self->_view bounds];
                     layer.timeValue = 0;
-					if (@available(macOS 11, *))
-					{
-						layer.position = NSMakePoint(0, SLIDER_HEIGHT_IN_PIXELS);
-					}
-					else
-					{
-						layer.position = NSMakePoint(CGRectGetMidX([self->_view bounds]), CGRectGetMidY([self->_view bounds]));
-					}
+					layer.position = NSMakePoint(0, SLIDER_HEIGHT_IN_PIXELS);
 					// NSLog(@"layer.position: %f, %f", layer.position.x, layer.position.y);
                     layer.delegate = self.viewHelper;
                     

--- a/appkit/SAMacView.m
+++ b/appkit/SAMacView.m
@@ -17,14 +17,7 @@
     [super setFrameSize:newSize];
     // NSLog(@"intercepted setFrameSize. new width = %f, new height = %f", newSize.width, newSize.height);
     self.layer.bounds = [self bounds];
-    if (@available(macOS 11, *))
-    {
-        self.layer.position = NSMakePoint(0, SLIDER_HEIGHT_IN_PIXELS);
-    }
-    else
-    {
-        self.layer.position = NSMakePoint(CGRectGetMidX([self bounds]), CGRectGetMidY([self bounds]));
-    }
+	self.layer.position = NSMakePoint(0, SLIDER_HEIGHT_IN_PIXELS);
     SALayer* saLayer = (SALayer*) self.layer;
     
     // TODO bounds has changed by more than one tile footprint…

--- a/spiritedarray.xcodeproj/project.pbxproj
+++ b/spiritedarray.xcodeproj/project.pbxproj
@@ -723,7 +723,7 @@
 					"\"$(SRCROOT)/lib\"",
 					"$(PROJECT_DIR)/lib",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12;
 				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.riverporpoise.spiritedarray;
 				PRODUCT_NAME = "Spirited Array";
@@ -747,7 +747,7 @@
 					"\"$(SRCROOT)/lib\"",
 					"$(PROJECT_DIR)/lib",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12;
 				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.riverporpoise.spiritedarray;
 				PRODUCT_NAME = "Spirited Array";


### PR DESCRIPTION
Since I don't currently have macOS 11 installed on a system to test with, I've decided to drop support for macOS 11 rather than coaxing #8 to work around it.

I hate to willingly drop support for any operating system version. But the layout model is radically different, and as far as I know there's no Mac that can run 11 but can't be upgraded to 12. Also, Spirited Array v1.0.3 — which does run on macOS 11 — isn't going anywhere.